### PR TITLE
Fix unicode problem in SConstruct

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 import os
 import sys
 import shutil


### PR DESCRIPTION
Add `# -*- coding: utf8 -*-` to SConstruct top.